### PR TITLE
671-concurrency-issue-when-resizing-a-window

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,6 +76,7 @@ dotnet_diagnostic.ca1043.severity = none # todo: why not to use indexer rather t
 dotnet_diagnostic.ca1814.severity = none # sometimes we need rectangle array
 dotnet_diagnostic.ca1058.severity = none # check why new documentation warns not to derive from ApplicationException. The purpose of last is to distinguish system exceptions like OOM, AssemblyLoadException etc from application logic
 dotnet_diagnostic.ca2000.severity = none # exceptions which are listed in the rule can be applied to any type
+dotnet_diagnostic.ca2002.severity = none # we use MethodImpl(Synchronized) for simplicity
 dotnet_diagnostic.CA2007.severity = none # we are assuming task continuation thread is fine by default
 dotnet_diagnostic.ca2213.severity = none # keeping field does not mean necessarity to dispose - it can be dispose somwhere else
 dotnet_diagnostic.CA2219.severity = none # I even would avoid discussing the speculative idea behind the rule. Nice that authors at least have understanding that the exception swallowing in filter clause is an issue, next step is to understand that exceptions can not be 100% avoided anywhere in dotnet. The case we need to suppress this rule is that exception from finally block is way more important than possible exception from try block. 

--- a/src/Consolonia.Core/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/ConsoloniaLifetime.cs
@@ -168,7 +168,8 @@ namespace Consolonia
             {
                 Dispatcher.UIThread.Post(() =>
                 {
-                    consoleWindow.Paint(new Rect(0, 0, consoleWindow.ClientSize.Width, consoleWindow.ClientSize.Height));
+                    consoleWindow.Paint(new Rect(0, 0, consoleWindow.ClientSize.Width,
+                        consoleWindow.ClientSize.Height));
                     MainWindow.InvalidateVisual();
                 });
             }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);

--- a/src/Consolonia.Core/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/ConsoloniaLifetime.cs
@@ -166,8 +166,11 @@ namespace Consolonia
 
             pauseTask.ContinueWith(_ =>
             {
-                consoleWindow.ClearScreen();
-                Dispatcher.UIThread.Post(() => { MainWindow.InvalidateVisual(); });
+                Dispatcher.UIThread.Post(() =>
+                {
+                    consoleWindow.Paint(new Rect(0, 0, consoleWindow.ClientSize.Width, consoleWindow.ClientSize.Height));
+                    MainWindow.InvalidateVisual();
+                });
             }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
 
             return Dispatcher.UIThread.InvokeAsync(() => { }).GetTask();

--- a/src/Consolonia.Core/ConsoloniaLifetime.cs
+++ b/src/Consolonia.Core/ConsoloniaLifetime.cs
@@ -90,6 +90,7 @@ namespace Consolonia
 
             MainWindow.Show();
 
+            Console.StartInputLoop();
             try
             {
                 Dispatcher.UIThread.MainLoop(_cts.Token);

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -39,7 +39,6 @@ namespace Consolonia.Core.Drawing
             _console = AvaloniaLocator.Current.GetRequiredService<IConsoleOutput>();
             _consoleTopLevelImpl = consoleTopLevelImpl;
             InitializeCacheInternal();
-            _consoleTopLevelImpl.CursorChanged += OnCursorChanged;
             _cursorTimer = new Timer(_ =>
                 {
                     lock (this)
@@ -51,6 +50,7 @@ namespace Consolonia.Core.Drawing
                     }
                 }, null, Timeout.Infinite,
                 Timeout.Infinite);
+            _consoleTopLevelImpl.CursorChanged += OnCursorChanged;
         }
 
         private void InitializeCacheInternal()

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Platform.Surfaces;
@@ -25,10 +24,10 @@ namespace Consolonia.Core.Drawing
 
         // cache of pixels written so we can ignore them if unchanged.
         private Pixel?[,] _cache = null!; //todo: why Pixel can be null
-        
+
         private ConsoleCursor _consoleCursor;
         private readonly Snapshot.Regions _cursorDirtyRegions = new();
-        private Timer _cursorTimer;
+        private readonly Timer _cursorTimer;
 #if FPS
         private readonly System.Diagnostics.Stopwatch _stopwatch = System.Diagnostics.Stopwatch.StartNew();
         private int _framesThisSecond;
@@ -144,10 +143,10 @@ namespace Consolonia.Core.Drawing
             Snapshot dirtyRegions = regions.GetSnapshotAndClear();
             dirtyRegions.Intersect(0, 0, pixelBuffer.Width, pixelBuffer.Height);
             if (dirtyRegions.IsEmpty) return;
-            
-            if(pixelBuffer.Width != _cache.GetLength(0) || pixelBuffer.Height != _cache.GetLength(1))
+
+            if (pixelBuffer.Width != _cache.GetLength(0) || pixelBuffer.Height != _cache.GetLength(1))
                 InitializeCacheInternal();
-            
+
 #if FPS
             var now = _stopwatch.Elapsed;
             var elapsed = now - _lastFpsUpdate;
@@ -308,7 +307,7 @@ namespace Consolonia.Core.Drawing
             Color result = contrastWithWhite > contrastWithBlack ? Colors.White : Colors.Black;
             return result;
         }
-        
+
         [MethodImpl(MethodImplOptions.Synchronized)]
         private void OnCursorChanged(ConsoleCursor consoleCursor)
         {
@@ -316,7 +315,7 @@ namespace Consolonia.Core.Drawing
                 return;
 
             _cursorTimer.Stop();
-            
+
             ConsoleCursor oldConsoleCursor = _consoleCursor;
             _consoleCursor = consoleCursor;
 
@@ -325,7 +324,7 @@ namespace Consolonia.Core.Drawing
                 oldConsoleCursor.Coordinate.Y, oldConsoleCursor.Width + 1, 1);
             var newCursorRect = new PixelRect(consoleCursor.Coordinate.X - 1,
                 consoleCursor.Coordinate.Y, consoleCursor.Width + 1, 1);
-            
+
             _cursorDirtyRegions.AddRect(oldCursorRect);
             _cursorDirtyRegions.AddRect(newCursorRect);
 

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -171,10 +171,10 @@ namespace Consolonia.Core.Drawing
             PixelBufferCoordinate? caretPosition = null;
             CaretStyle? caretStyle = null;
 
-            for (ushort y = dirtyRegions.MinY; y < dirtyRegions.MaxY; y++)
+            for (ushort y = 0; y < pixelBuffer.Height; y++)
             {
                 bool isWide = false;
-                // we can not run only from MinX to MaxX because of wide characters
+                // we can not run only from MinX to MaxX because of wide characters, also we can not run MinY/MaxY because we need to detect caret
                 for (ushort x = 0; x < pixelBuffer.Width; x++)
                 {
                     Pixel pixel = pixelBuffer[x, y];

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -27,7 +27,7 @@ namespace Consolonia.Core.Drawing
 
         private ConsoleCursor _consoleCursor;
         private readonly Snapshot.Regions _cursorDirtyRegions = new();
-        private readonly Timer _cursorTimer;
+        private Timer _cursorTimer;
 #if FPS
         private readonly System.Diagnostics.Stopwatch _stopwatch = System.Diagnostics.Stopwatch.StartNew();
         private int _framesThisSecond;
@@ -42,8 +42,13 @@ namespace Consolonia.Core.Drawing
             _consoleTopLevelImpl.CursorChanged += OnCursorChanged;
             _cursorTimer = new Timer(_ =>
                 {
-                    _cursorTimer.Stop();
-                    RenderToDevice(_cursorDirtyRegions);
+                    lock (this)
+                    {
+                        if (_cursorTimer == null)
+                            return;
+                        _cursorTimer.Stop();
+                        RenderToDevice(_cursorDirtyRegions);
+                    }
                 }, null, Timeout.Infinite,
                 Timeout.Infinite);
         }
@@ -64,6 +69,7 @@ namespace Consolonia.Core.Drawing
         {
             _consoleTopLevelImpl.CursorChanged -= OnCursorChanged;
             _cursorTimer.Dispose();
+            _cursorTimer = null!;
         }
 
         public void Save(string fileName, int? quality = null)

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -27,7 +27,7 @@ namespace Consolonia.Core.Drawing
 
         private ConsoleCursor _consoleCursor;
         private readonly Snapshot.Regions _cursorDirtyRegions = new();
-        private Timer _cursorTimer;
+        private Timer? _cursorTimer;
 #if FPS
         private readonly System.Diagnostics.Stopwatch _stopwatch = System.Diagnostics.Stopwatch.StartNew();
         private int _framesThisSecond;
@@ -68,8 +68,8 @@ namespace Consolonia.Core.Drawing
         public void Dispose()
         {
             _consoleTopLevelImpl.CursorChanged -= OnCursorChanged;
-            _cursorTimer.Dispose();
-            _cursorTimer = null!;
+            _cursorTimer!.Dispose();
+            _cursorTimer = null;
         }
 
         public void Save(string fileName, int? quality = null)
@@ -320,6 +320,10 @@ namespace Consolonia.Core.Drawing
             if (_consoleCursor.CompareTo(consoleCursor) == 0)
                 return;
 
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if(_cursorTimer == null)
+                return;
+            
             _cursorTimer.Stop();
 
             ConsoleCursor oldConsoleCursor = _consoleCursor;

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -4,14 +4,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Platform.Surfaces;
-using Avalonia.Threading;
 using Consolonia.Controls;
 using Consolonia.Core.Drawing.PixelBufferImplementation;
+using Consolonia.Core.Helpers;
 using Consolonia.Core.Infrastructure;
 
 namespace Consolonia.Core.Drawing
@@ -24,9 +25,10 @@ namespace Consolonia.Core.Drawing
 
         // cache of pixels written so we can ignore them if unchanged.
         private Pixel?[,] _cache = null!; //todo: why Pixel can be null
+        
         private ConsoleCursor _consoleCursor;
-
-        private bool _renderPending;
+        private readonly Snapshot.Regions _cursorDirtyRegions = new();
+        private Timer _cursorTimer;
 #if FPS
         private readonly System.Diagnostics.Stopwatch _stopwatch = System.Diagnostics.Stopwatch.StartNew();
         private int _framesThisSecond;
@@ -35,12 +37,18 @@ namespace Consolonia.Core.Drawing
 #endif
         internal RenderTarget(ConsoleWindowImpl consoleTopLevelImpl)
         {
-            _console = AvaloniaLocator.Current.GetService<IConsoleOutput>()!;
+            _console = AvaloniaLocator.Current.GetRequiredService<IConsoleOutput>();
             _consoleTopLevelImpl = consoleTopLevelImpl;
             InitializeCacheInternal();
             _consoleTopLevelImpl.Resized += OnResized;
             _consoleTopLevelImpl.CursorChanged += OnCursorChanged;
             _consoleTopLevelImpl.ClearScreenRequested += OnClearScreenRequested;
+            _cursorTimer = new Timer(_ =>
+                {
+                    _cursorTimer.Stop();
+                    RenderToDevice(_cursorDirtyRegions);
+                }, null, Timeout.Infinite,
+                Timeout.Infinite);
         }
 
         private void InitializeCacheInternal()
@@ -64,11 +72,13 @@ namespace Consolonia.Core.Drawing
 
         public PixelBuffer Buffer => _consoleTopLevelImpl.PixelBuffer;
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Dispose()
         {
             _consoleTopLevelImpl.Resized -= OnResized;
             _consoleTopLevelImpl.CursorChanged -= OnCursorChanged;
             _consoleTopLevelImpl.ClearScreenRequested -= OnClearScreenRequested;
+            _cursorTimer.Dispose();
         }
 
         public void Save(string fileName, int? quality = null)
@@ -90,7 +100,7 @@ namespace Consolonia.Core.Drawing
         {
             try
             {
-                RenderToDevice();
+                RenderToDevice(_consoleTopLevelImpl.DirtyRegions);
             }
             catch (InvalidDrawingContextException)
             {
@@ -150,11 +160,12 @@ namespace Consolonia.Core.Drawing
 
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        private void RenderToDevice()
+        private void RenderToDevice(Snapshot.Regions regions)
         {
-            _renderPending = false;
             PixelBuffer pixelBuffer = _consoleTopLevelImpl.PixelBuffer;
-            Snapshot dirtyRegions = _consoleTopLevelImpl.DirtyRegions.GetSnapshotAndClear();
+            Snapshot dirtyRegions = regions.GetSnapshotAndClear();
+            dirtyRegions.Intersect(0, 0, pixelBuffer.Width, pixelBuffer.Height);
+            if (dirtyRegions.IsEmpty) return;
 
 #if FPS
             var now = _stopwatch.Elapsed;
@@ -174,9 +185,10 @@ namespace Consolonia.Core.Drawing
             PixelBufferCoordinate? caretPosition = null;
             CaretStyle? caretStyle = null;
 
-            for (ushort y = 0; y < pixelBuffer.Height; y++)
+            for (ushort y = dirtyRegions.MinY; y < dirtyRegions.MaxY; y++)
             {
                 bool isWide = false;
+                // we can not run only from MinX to MaxX because of wide characters
                 for (ushort x = 0; x < pixelBuffer.Width; x++)
                 {
                     Pixel pixel = pixelBuffer[x, y];
@@ -317,12 +329,15 @@ namespace Consolonia.Core.Drawing
             Color result = contrastWithWhite > contrastWithBlack ? Colors.White : Colors.Black;
             return result;
         }
-
+        
+        [MethodImpl(MethodImplOptions.Synchronized)]
         private void OnCursorChanged(ConsoleCursor consoleCursor)
         {
             if (_consoleCursor.CompareTo(consoleCursor) == 0)
                 return;
 
+            _cursorTimer.Stop();
+            
             ConsoleCursor oldConsoleCursor = _consoleCursor;
             _consoleCursor = consoleCursor;
 
@@ -331,23 +346,11 @@ namespace Consolonia.Core.Drawing
                 oldConsoleCursor.Coordinate.Y, oldConsoleCursor.Width + 1, 1);
             var newCursorRect = new PixelRect(consoleCursor.Coordinate.X - 1,
                 consoleCursor.Coordinate.Y, consoleCursor.Width + 1, 1);
-            _consoleTopLevelImpl.DirtyRegions.AddRect(oldCursorRect);
-            _consoleTopLevelImpl.DirtyRegions.AddRect(newCursorRect);
+            
+            _cursorDirtyRegions.AddRect(oldCursorRect);
+            _cursorDirtyRegions.AddRect(newCursorRect);
 
-            if (!_renderPending)
-            {
-                _renderPending = true;
-
-                // this gates rendering of cursor to (60fps) to avoid excessive rendering when moving cursor fast
-                DispatcherTimer.RunOnce(() =>
-                {
-                    if (_renderPending)
-                    {
-                        _renderPending = false;
-                        RenderToDevice();
-                    }
-                }, TimeSpan.FromMilliseconds(16), DispatcherPriority.UiThreadRender);
-            }
+            _cursorTimer.StartOnce(16);
         }
     }
 }

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -40,9 +40,7 @@ namespace Consolonia.Core.Drawing
             _console = AvaloniaLocator.Current.GetRequiredService<IConsoleOutput>();
             _consoleTopLevelImpl = consoleTopLevelImpl;
             InitializeCacheInternal();
-            _consoleTopLevelImpl.Resized += OnResized;
             _consoleTopLevelImpl.CursorChanged += OnCursorChanged;
-            _consoleTopLevelImpl.ClearScreenRequested += OnClearScreenRequested;
             _cursorTimer = new Timer(_ =>
                 {
                     _cursorTimer.Stop();
@@ -56,28 +54,16 @@ namespace Consolonia.Core.Drawing
             _cache = InitializeCache(_consoleTopLevelImpl.PixelBuffer.Width, _consoleTopLevelImpl.PixelBuffer.Height);
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        private void OnClearScreenRequested()
-        {
-            _console.ClearScreen();
-            _console.Flush();
-            InitializeCacheInternal();
-        }
-
         public RenderTarget(IEnumerable<IPlatformRenderSurface> surfaces)
             : this(surfaces.OfType<ConsoleWindowImpl>()
                 .Single())
         {
         }
 
-        public PixelBuffer Buffer => _consoleTopLevelImpl.PixelBuffer;
-
         [MethodImpl(MethodImplOptions.Synchronized)]
         public void Dispose()
         {
-            _consoleTopLevelImpl.Resized -= OnResized;
             _consoleTopLevelImpl.CursorChanged -= OnCursorChanged;
-            _consoleTopLevelImpl.ClearScreenRequested -= OnClearScreenRequested;
             _cursorTimer.Dispose();
         }
 
@@ -138,14 +124,6 @@ namespace Consolonia.Core.Drawing
             return new DrawingContextImpl(_consoleTopLevelImpl);
         }
 
-
-        [MethodImpl(MethodImplOptions.Synchronized)]
-        private void OnResized(Size size, WindowResizeReason reason)
-        {
-            // todo: should we check the reason?
-            InitializeCacheInternal();
-        }
-
         private static Pixel?[,] InitializeCache(ushort width, ushort height)
         {
             var cache = new Pixel?[width, height];
@@ -167,6 +145,10 @@ namespace Consolonia.Core.Drawing
             dirtyRegions.Intersect(0, 0, pixelBuffer.Width, pixelBuffer.Height);
             if (dirtyRegions.IsEmpty) return;
 
+            // checking whether width or height of pixelBuffer is different now from the cache
+            if(pixelBuffer.Width != _cache.GetLength(0) || pixelBuffer.Height != _cache.GetLength(1))
+                InitializeCacheInternal();
+            
 #if FPS
             var now = _stopwatch.Elapsed;
             var elapsed = now - _lastFpsUpdate;

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -321,9 +321,9 @@ namespace Consolonia.Core.Drawing
                 return;
 
             // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            if(_cursorTimer == null)
+            if (_cursorTimer == null)
                 return;
-            
+
             _cursorTimer.Stop();
 
             ConsoleCursor oldConsoleCursor = _consoleCursor;

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -144,8 +144,7 @@ namespace Consolonia.Core.Drawing
             Snapshot dirtyRegions = regions.GetSnapshotAndClear();
             dirtyRegions.Intersect(0, 0, pixelBuffer.Width, pixelBuffer.Height);
             if (dirtyRegions.IsEmpty) return;
-
-            // checking whether width or height of pixelBuffer is different now from the cache
+            
             if(pixelBuffer.Width != _cache.GetLength(0) || pixelBuffer.Height != _cache.GetLength(1))
                 InitializeCacheInternal();
             

--- a/src/Consolonia.Core/Drawing/RenderTarget.cs
+++ b/src/Consolonia.Core/Drawing/RenderTarget.cs
@@ -258,8 +258,6 @@ namespace Consolonia.Core.Drawing
                             continue;
                     }
 
-                    //todo: indexOutOfRange during resize
-
                     _console.WritePixel(new PixelBufferCoordinate(x, y), in pixel);
 
                     _cache[x, y] = pixel;

--- a/src/Consolonia.Core/Dummy/DummyConsole.cs
+++ b/src/Consolonia.Core/Dummy/DummyConsole.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Consolonia.Controls;
 using Consolonia.Core.Drawing.PixelBufferImplementation;
 using Consolonia.Core.Infrastructure;
@@ -14,6 +15,11 @@ namespace Consolonia.Core.Dummy
         public DummyConsole(ushort width, ushort height)
             : base(new DummyConsoleOutput(width, height))
         {
+        }
+
+        public override void StartInputLoop()
+        {
+            
         }
     }
 
@@ -46,6 +52,7 @@ namespace Consolonia.Core.Dummy
         {
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void SetCaretPosition(PixelBufferCoordinate bufferPoint)
         {
             _caretPosition = bufferPoint;
@@ -87,11 +94,13 @@ namespace Consolonia.Core.Dummy
         {
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void ClearOutput()
         {
             SetCaretPosition(new PixelBufferCoordinate(0, 0));
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/src/Consolonia.Core/Dummy/DummyConsole.cs
+++ b/src/Consolonia.Core/Dummy/DummyConsole.cs
@@ -19,7 +19,6 @@ namespace Consolonia.Core.Dummy
 
         public override void StartInputLoop()
         {
-            
         }
     }
 

--- a/src/Consolonia.Core/Helpers/Helper.cs
+++ b/src/Consolonia.Core/Helpers/Helper.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Threading;
@@ -10,6 +11,16 @@ namespace Consolonia.Core.Helpers
         {
             //todo: check if avalonia exiting to break the loop
             while (AvaloniaLocator.Current.GetService<IDispatcherImpl>() == null) await Task.Yield();
+        }
+
+        public static void StartOnce(this Timer timer, int ms)
+        {
+            timer.Change(ms, Timeout.Infinite);
+        }
+        
+        public static void Stop(this Timer timer)
+        {
+            timer.Change(Timeout.Infinite, Timeout.Infinite);
         }
     }
 }

--- a/src/Consolonia.Core/Helpers/Helper.cs
+++ b/src/Consolonia.Core/Helpers/Helper.cs
@@ -17,7 +17,7 @@ namespace Consolonia.Core.Helpers
         {
             timer.Change(ms, Timeout.Infinite);
         }
-        
+
         public static void Stop(this Timer timer)
         {
             timer.Change(Timeout.Infinite, Timeout.Infinite);

--- a/src/Consolonia.Core/Infrastructure/AnsiConsoleOutput.cs
+++ b/src/Consolonia.Core/Infrastructure/AnsiConsoleOutput.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Avalonia;
 using Avalonia.Media;
@@ -13,6 +14,7 @@ namespace Consolonia.Core.Infrastructure
     /// </summary>
     /// <remarks>
     ///     This console buffers all output and only writes to the console on Flush.
+    ///     Thread safe
     /// </remarks>
     public class AnsiConsoleOutput : PauseBase, IConsoleOutput
 
@@ -35,12 +37,14 @@ namespace Consolonia.Core.Infrastructure
 
         public PixelBufferSize Size { get; set; }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void SetTitle(string title)
         {
             WriteText(Esc.SetWindowTitle(title));
             Flush();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void SetCaretPosition(PixelBufferCoordinate bufferPoint)
         {
             if (bufferPoint.Equals(GetCaretPosition())) return;
@@ -48,11 +52,13 @@ namespace Consolonia.Core.Infrastructure
             SetCaretPositionInternal(bufferPoint);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public PixelBufferCoordinate GetCaretPosition()
         {
             return _headBufferPoint;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void WritePixel(PixelBufferCoordinate position, in Pixel pixel)
         {
             if (pixel.Width <=
@@ -168,6 +174,7 @@ namespace Consolonia.Core.Infrastructure
             }
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Flush()
         {
             if (_outputBuffer.Length > 0)
@@ -183,12 +190,14 @@ namespace Consolonia.Core.Infrastructure
         /// </summary>
         /// <remarks>This does not move the caret position, so should only be used for escape commands</remarks>
         /// <param name="str"></param>
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void WriteText(string str)
         {
             WaitPauseTaskIfNecessary();
             _outputBuffer.Append(str);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void PrepareConsole()
         {
 #pragma warning disable CA1303 // Do not pass literals as localized parameters
@@ -213,6 +222,7 @@ namespace Consolonia.Core.Infrastructure
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void RestoreConsole()
         {
             WriteText(Esc.DisableAlternateBuffer);
@@ -221,6 +231,7 @@ namespace Consolonia.Core.Infrastructure
             Flush();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void SetCaretStyle(CaretStyle caretStyle)
         {
             switch (caretStyle)
@@ -248,18 +259,21 @@ namespace Consolonia.Core.Infrastructure
             }
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void HideCaret()
         {
             WriteText(Esc.HideCursor);
             Flush();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void ShowCaret()
         {
             WriteText(Esc.ShowCursor);
             Flush();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void ClearScreen()
         {
             WriteText(Esc.ClearScreen);
@@ -312,7 +326,7 @@ namespace Consolonia.Core.Infrastructure
         ///     Write char to the console
         /// </summary>
         /// <param name="ch"></param>
-        public void WriteChar(char ch)
+        private void WriteChar(char ch)
         {
             if (ch > 0)
                 _outputBuffer.Append(ch);

--- a/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Input;
@@ -15,7 +16,8 @@ namespace Consolonia.Core.Infrastructure
     /// </summary>
     /// <remarks>
     ///     This implements disposable and eventing for IConsoleInput and
-    ///     wraps around internal IConsoleOutput
+    ///     wraps around internal IConsoleOutput.
+    ///  Thread-safe
     /// </remarks>
     public abstract class ConsoleBase : PauseBase, IConsole, IDisposable
     {
@@ -65,6 +67,7 @@ namespace Consolonia.Core.Infrastructure
         protected async Task DispatchInputAsync(Action action)
 #pragma warning restore CA1822
         {
+            //todo: key and mouse input now can be dispatched on any thread (from avalonia 12)
             await Dispatcher.UIThread.InvokeAsync(action, DispatcherPriority.Input);
         }
 
@@ -74,6 +77,7 @@ namespace Consolonia.Core.Infrastructure
         public event Action<RawPointerEventType, Point, Vector?, RawInputModifiers> MouseEvent;
         public event Action<bool> FocusEvent;
         public event Action<string, ulong, CanBeHandledEventArgs> TextInputEvent;
+        public abstract void StartInputLoop();
 
         protected void RaiseMouseEvent(RawPointerEventType eventType, Point point, Vector? wheelDelta,
             RawInputModifiers modifiers)
@@ -101,10 +105,12 @@ namespace Consolonia.Core.Infrastructure
         #endregion
 
         #region IConsoleOutput
-
+        
         public PixelBufferSize Size
         {
+            [MethodImpl(MethodImplOptions.Synchronized)]
             get => _consoleOutput.Size;
+            [MethodImpl(MethodImplOptions.Synchronized)]
             set
             {
                 // ReSharper disable once UsageOfDefaultStructEquality //todo: low use special equality interfaces
@@ -121,63 +127,75 @@ namespace Consolonia.Core.Infrastructure
 
         public event Action Resized;
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ClearScreen()
         {
             _consoleOutput.ClearScreen();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual PixelBufferCoordinate GetCaretPosition()
         {
             return _consoleOutput.GetCaretPosition();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void HideCaret()
         {
             _consoleOutput.HideCaret();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void PrepareConsole()
         {
             _consoleOutput.PrepareConsole();
             Capabilities |= _consoleOutput.Capabilities;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void WritePixel(PixelBufferCoordinate position, in Pixel pixel)
         {
             _consoleOutput.WritePixel(position, in pixel);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void RestoreConsole()
         {
             _consoleOutput.RestoreConsole();
             _consoleOutput.Flush();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetCaretPosition(PixelBufferCoordinate bufferPoint)
         {
             _consoleOutput.SetCaretPosition(bufferPoint);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetCaretStyle(CaretStyle caretStyle)
         {
             _consoleOutput.SetCaretStyle(caretStyle);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetTitle(string title)
         {
             _consoleOutput.SetTitle(title);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ShowCaret()
         {
             _consoleOutput.ShowCaret();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void WriteText(string str)
         {
             _consoleOutput.WriteText(str);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         protected bool CheckSize()
         {
             if (Size.Width == Console.WindowWidth && Size.Height == Console.WindowHeight) return false;
@@ -199,6 +217,7 @@ namespace Consolonia.Core.Infrastructure
             }
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Dispose()
         {
 #pragma warning disable CA1063 // Implement IDisposable Correctly
@@ -209,6 +228,7 @@ namespace Consolonia.Core.Infrastructure
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Flush()
         {
             _consoleOutput.Flush();

--- a/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
@@ -108,16 +108,20 @@ namespace Consolonia.Core.Infrastructure
         
         public PixelBufferSize Size
         {
-            [MethodImpl(MethodImplOptions.Synchronized)]
             get => _consoleOutput.Size;
-            [MethodImpl(MethodImplOptions.Synchronized)]
             set
             {
-                // ReSharper disable once UsageOfDefaultStructEquality //todo: low use special equality interfaces
-                if (_consoleOutput.Size.Equals(value))
-                    return;
+#pragma warning disable CA2002 // we are using Synchronized for simplicity
+                lock (this)
+#pragma warning restore CA2002
+                {
+                    // ReSharper disable once UsageOfDefaultStructEquality //todo: low use special equality interfaces
+                    if (_consoleOutput.Size.Equals(value))
+                        return;
 
-                _consoleOutput.Size = value;
+                    _consoleOutput.Size = value;
+                }
+
                 Resized?.Invoke();
             }
         }
@@ -195,7 +199,6 @@ namespace Consolonia.Core.Infrastructure
             _consoleOutput.WriteText(str);
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         protected bool CheckSize()
         {
             if (Size.Width == Console.WindowWidth && Size.Height == Console.WindowHeight) return false;

--- a/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
@@ -112,9 +112,7 @@ namespace Consolonia.Core.Infrastructure
             get => _consoleOutput.Size;
             set
             {
-#pragma warning disable CA2002 // we are using Synchronized for simplicity
                 lock (this)
-#pragma warning restore CA2002
                 {
                     // ReSharper disable once UsageOfDefaultStructEquality //todo: low use special equality interfaces
                     if (_consoleOutput.Size.Equals(value))

--- a/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
@@ -108,6 +108,7 @@ namespace Consolonia.Core.Infrastructure
         
         public PixelBufferSize Size
         {
+            [MethodImpl(MethodImplOptions.Synchronized)]
             get => _consoleOutput.Size;
             set
             {
@@ -131,19 +132,16 @@ namespace Consolonia.Core.Infrastructure
 
         public event Action Resized;
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ClearScreen()
         {
             _consoleOutput.ClearScreen();
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual PixelBufferCoordinate GetCaretPosition()
         {
             return _consoleOutput.GetCaretPosition();
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void HideCaret()
         {
             _consoleOutput.HideCaret();
@@ -156,7 +154,6 @@ namespace Consolonia.Core.Infrastructure
             Capabilities |= _consoleOutput.Capabilities;
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void WritePixel(PixelBufferCoordinate position, in Pixel pixel)
         {
             _consoleOutput.WritePixel(position, in pixel);
@@ -169,36 +166,31 @@ namespace Consolonia.Core.Infrastructure
             _consoleOutput.Flush();
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetCaretPosition(PixelBufferCoordinate bufferPoint)
         {
             _consoleOutput.SetCaretPosition(bufferPoint);
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetCaretStyle(CaretStyle caretStyle)
         {
             _consoleOutput.SetCaretStyle(caretStyle);
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetTitle(string title)
         {
             _consoleOutput.SetTitle(title);
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ShowCaret()
         {
             _consoleOutput.ShowCaret();
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void WriteText(string str)
         {
             _consoleOutput.WriteText(str);
         }
-
+        
         protected bool CheckSize()
         {
             if (Size.Width == Console.WindowWidth && Size.Height == Console.WindowHeight) return false;
@@ -231,7 +223,6 @@ namespace Consolonia.Core.Infrastructure
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public void Flush()
         {
             _consoleOutput.Flush();

--- a/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleBase.cs
@@ -17,7 +17,7 @@ namespace Consolonia.Core.Infrastructure
     /// <remarks>
     ///     This implements disposable and eventing for IConsoleInput and
     ///     wraps around internal IConsoleOutput.
-    ///  Thread-safe
+    ///     Thread-safe
     /// </remarks>
     public abstract class ConsoleBase : PauseBase, IConsole, IDisposable
     {
@@ -105,7 +105,7 @@ namespace Consolonia.Core.Infrastructure
         #endregion
 
         #region IConsoleOutput
-        
+
         public PixelBufferSize Size
         {
             [MethodImpl(MethodImplOptions.Synchronized)]
@@ -190,7 +190,7 @@ namespace Consolonia.Core.Infrastructure
         {
             _consoleOutput.WriteText(str);
         }
-        
+
         protected bool CheckSize()
         {
             if (Size.Width == Console.WindowWidth && Size.Height == Console.WindowHeight) return false;

--- a/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
+++ b/src/Consolonia.Core/Infrastructure/ConsoleWindow.cs
@@ -592,13 +592,5 @@ namespace Consolonia.Core.Infrastructure
         {
             CursorChanged?.Invoke(obj);
         }
-
-        public event Action ClearScreenRequested;
-
-        public void ClearScreen()
-        {
-            DirtyRegions.AddRect(PixelBuffer.Size);
-            ClearScreenRequested?.Invoke();
-        }
     }
 }

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using Avalonia.Input;
@@ -72,7 +73,11 @@ namespace Consolonia.Core.Infrastructure
             ]);
             // ReSharper disable VirtualMemberCallInConstructor
             PrepareConsole();
-
+        }
+        
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public override void StartInputLoop()
+        {
             StartSizeCheckTimerAsync();
             StartInputReading();
             _inputBuffer.StartReading();

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsole.cs
@@ -74,7 +74,7 @@ namespace Consolonia.Core.Infrastructure
             // ReSharper disable VirtualMemberCallInConstructor
             PrepareConsole();
         }
-        
+
         [MethodImpl(MethodImplOptions.Synchronized)]
         public override void StartInputLoop()
         {

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsoleOutput.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsoleOutput.cs
@@ -34,34 +34,37 @@ namespace Consolonia.Core.Infrastructure
 
         public ConsoleCapabilities Capabilities { get; protected set; }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetTitle(string title)
         {
             WaitPauseTaskIfNecessary();
             Console.Title = title;
         }
-
-        [MethodImpl(MethodImplOptions.Synchronized)]
+        
         public virtual void SetCaretPosition(PixelBufferCoordinate bufferPoint)
         {
             WaitPauseTaskIfNecessary();
-            try
+            lock (this)
             {
-                Console.SetCursorPosition(bufferPoint.X, bufferPoint.Y);
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                // ignore
-                // this happens while resizing.
+                try
+                {
+                    Console.SetCursorPosition(bufferPoint.X, bufferPoint.Y);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // ignore
+                    // this happens while resizing.
+                }
             }
         }
-
-        [MethodImpl(MethodImplOptions.Synchronized)]
+        
         public virtual PixelBufferCoordinate GetCaretPosition()
         {
             WaitPauseTaskIfNecessary();
-            (int left, int top) = Console.GetCursorPosition();
-            return new PixelBufferCoordinate((ushort)left, (ushort)top);
+            lock (this)
+            {
+                (int left, int top) = Console.GetCursorPosition();
+                return new PixelBufferCoordinate((ushort)left, (ushort)top);
+            }
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
@@ -108,28 +111,28 @@ namespace Consolonia.Core.Infrastructure
             _currentPosition = new PixelBufferCoordinate((ushort)(_currentPosition.X + pixel.Width),
                 _currentPosition.Y);
         }
-
-        [MethodImpl(MethodImplOptions.Synchronized)]
+        
         public virtual void Flush()
         {
-            if (_stringBuilder.Length == 0)
-                return;
-
             WaitPauseTaskIfNecessary();
 
-            // Debug.WriteLine($"[{_currentBufferPoint.X},{_currentBufferPoint.Y}] {_lastForegroundColor} on {_lastBackgroundColor} '{_stringBuilder}'");
-            Console.Write(_stringBuilder.ToString());
-            _stringBuilder.Clear();
+            lock (this)
+            {
+                if (_stringBuilder.Length == 0)
+                    return;
+                // Debug.WriteLine($"[{_currentBufferPoint.X},{_currentBufferPoint.Y}] {_lastForegroundColor} on {_lastBackgroundColor} '{_stringBuilder}'");
+                Console.Write(_stringBuilder.ToString());
+                _stringBuilder.Clear();
+            }
         }
-
-        [MethodImpl(MethodImplOptions.Synchronized)]
+        
         public virtual void WriteText(string str)
         {
             WaitPauseTaskIfNecessary();
+            
             Console.Write(str);
         }
-
-        [MethodImpl(MethodImplOptions.Synchronized)]
+        
         public virtual void SetCaretStyle(CaretStyle caretStyle)
         {
             WaitPauseTaskIfNecessary();
@@ -155,14 +158,12 @@ namespace Consolonia.Core.Infrastructure
             }
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void HideCaret()
         {
             WaitPauseTaskIfNecessary();
             Console.CursorVisible = false;
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ShowCaret()
         {
             WaitPauseTaskIfNecessary();
@@ -188,14 +189,12 @@ namespace Consolonia.Core.Infrastructure
             Console.Clear();
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void RestoreConsole()
         {
             Console.ForegroundColor = _originalForeground;
             Console.BackgroundColor = _originalBackground;
         }
 
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ClearScreen()
         {
             WaitPauseTaskIfNecessary();

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsoleOutput.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsoleOutput.cs
@@ -39,7 +39,7 @@ namespace Consolonia.Core.Infrastructure
             WaitPauseTaskIfNecessary();
             Console.Title = title;
         }
-        
+
         public virtual void SetCaretPosition(PixelBufferCoordinate bufferPoint)
         {
             WaitPauseTaskIfNecessary();
@@ -56,7 +56,7 @@ namespace Consolonia.Core.Infrastructure
                 }
             }
         }
-        
+
         public virtual PixelBufferCoordinate GetCaretPosition()
         {
             WaitPauseTaskIfNecessary();
@@ -111,7 +111,7 @@ namespace Consolonia.Core.Infrastructure
             _currentPosition = new PixelBufferCoordinate((ushort)(_currentPosition.X + pixel.Width),
                 _currentPosition.Y);
         }
-        
+
         public virtual void Flush()
         {
             WaitPauseTaskIfNecessary();
@@ -125,14 +125,14 @@ namespace Consolonia.Core.Infrastructure
                 _stringBuilder.Clear();
             }
         }
-        
+
         public virtual void WriteText(string str)
         {
             WaitPauseTaskIfNecessary();
-            
+
             Console.Write(str);
         }
-        
+
         public virtual void SetCaretStyle(CaretStyle caretStyle)
         {
             WaitPauseTaskIfNecessary();

--- a/src/Consolonia.Core/Infrastructure/DefaultNetConsoleOutput.cs
+++ b/src/Consolonia.Core/Infrastructure/DefaultNetConsoleOutput.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Avalonia.Media;
 using Consolonia.Controls;
@@ -33,12 +34,14 @@ namespace Consolonia.Core.Infrastructure
 
         public ConsoleCapabilities Capabilities { get; protected set; }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetTitle(string title)
         {
             WaitPauseTaskIfNecessary();
             Console.Title = title;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetCaretPosition(PixelBufferCoordinate bufferPoint)
         {
             WaitPauseTaskIfNecessary();
@@ -53,6 +56,7 @@ namespace Consolonia.Core.Infrastructure
             }
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual PixelBufferCoordinate GetCaretPosition()
         {
             WaitPauseTaskIfNecessary();
@@ -60,6 +64,7 @@ namespace Consolonia.Core.Infrastructure
             return new PixelBufferCoordinate((ushort)left, (ushort)top);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void WritePixel(PixelBufferCoordinate position, in Pixel pixel)
         {
             // Width 0 is the trailing placeholder cell of a previously rendered wide glyph.
@@ -104,6 +109,7 @@ namespace Consolonia.Core.Infrastructure
                 _currentPosition.Y);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void Flush()
         {
             if (_stringBuilder.Length == 0)
@@ -116,12 +122,14 @@ namespace Consolonia.Core.Infrastructure
             _stringBuilder.Clear();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void WriteText(string str)
         {
             WaitPauseTaskIfNecessary();
             Console.Write(str);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void SetCaretStyle(CaretStyle caretStyle)
         {
             WaitPauseTaskIfNecessary();
@@ -147,18 +155,21 @@ namespace Consolonia.Core.Infrastructure
             }
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void HideCaret()
         {
             WaitPauseTaskIfNecessary();
             Console.CursorVisible = false;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ShowCaret()
         {
             WaitPauseTaskIfNecessary();
             Console.CursorVisible = true;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void PrepareConsole()
         {
             Console.OutputEncoding = Encoding.UTF8;
@@ -177,12 +188,14 @@ namespace Consolonia.Core.Infrastructure
             Console.Clear();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void RestoreConsole()
         {
             Console.ForegroundColor = _originalForeground;
             Console.BackgroundColor = _originalBackground;
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public virtual void ClearScreen()
         {
             WaitPauseTaskIfNecessary();

--- a/src/Consolonia.Core/Infrastructure/IConsole.cs
+++ b/src/Consolonia.Core/Infrastructure/IConsole.cs
@@ -20,5 +20,6 @@ namespace Consolonia.Core.Infrastructure
         event Action<RawPointerEventType, Point, Vector?, RawInputModifiers> MouseEvent;
 
         event Action<bool> FocusEvent;
+        void StartInputLoop();
     }
 }

--- a/src/Consolonia.Core/Infrastructure/Regions.cs
+++ b/src/Consolonia.Core/Infrastructure/Regions.cs
@@ -9,12 +9,6 @@ namespace Consolonia.Core.Infrastructure
     /// </summary>
     internal class Snapshot
     {
-        public ushort MinY { get; private set; }
-        public ushort MaxY { get; private set; }
-        public ushort MinX { get; private set; }
-        public ushort MaxX { get; private set; }
-        
-        public bool IsEmpty => _rectangles.Count == 0;
         private IReadOnlyList<PixelRect> _rectangles;
 
         private Snapshot(IReadOnlyList<PixelRect> rectangles)
@@ -23,6 +17,13 @@ namespace Consolonia.Core.Infrastructure
 
             CalculateMinMax();
         }
+
+        public ushort MinY { get; private set; }
+        public ushort MaxY { get; private set; }
+        public ushort MinX { get; private set; }
+        public ushort MaxX { get; private set; }
+
+        public bool IsEmpty => _rectangles.Count == 0;
 
         private void InitializeMinMax()
         {
@@ -35,7 +36,7 @@ namespace Consolonia.Core.Infrastructure
         private void CalculateMinMax()
         {
             InitializeMinMax();
-            
+
             for (int i = 0; i < _rectangles.Count; i++)
             {
                 PixelRect rect = _rectangles[i];
@@ -75,6 +76,20 @@ namespace Consolonia.Core.Infrastructure
         public bool Contains(ushort x, ushort y, bool inclusive)
         {
             return Contains(new PixelPoint(x, y), inclusive);
+        }
+
+        public void Intersect(int x, int y, ushort width, ushort height)
+        {
+            var result = new List<PixelRect>();
+            foreach (PixelRect rectangle in _rectangles)
+            {
+                PixelRect intersected = rectangle.Intersect(new PixelRect(x, y, width, height));
+                if (!intersected.IsEmpty())
+                    result.Add(intersected);
+            }
+
+            _rectangles = result.AsReadOnly();
+            CalculateMinMax();
         }
 
         /// <summary>
@@ -117,20 +132,6 @@ namespace Consolonia.Core.Infrastructure
                     return snapshot;
                 }
             }
-        }
-
-        public void Intersect(int x, int y, ushort width, ushort height)
-        {
-            var result = new List<PixelRect>();
-            foreach (PixelRect rectangle in _rectangles)
-            {
-                PixelRect intersected = rectangle.Intersect(new PixelRect(x, y, width, height));
-                if(!intersected.IsEmpty())
-                    result.Add(intersected);
-            } 
-            
-            _rectangles = result.AsReadOnly();
-            CalculateMinMax();
         }
     }
 }

--- a/src/Consolonia.Core/Infrastructure/Regions.cs
+++ b/src/Consolonia.Core/Infrastructure/Regions.cs
@@ -9,10 +9,10 @@ namespace Consolonia.Core.Infrastructure
     /// </summary>
     internal class Snapshot
     {
-        public ushort MinY { get; private set; } = ushort.MaxValue;
-        public ushort MaxY { get; private set; } = ushort.MinValue;
-        public ushort MinX { get; private set; } = ushort.MaxValue;
-        public ushort MaxX { get; private set; } = ushort.MinValue;
+        public ushort MinY { get; private set; }
+        public ushort MaxY { get; private set; }
+        public ushort MinX { get; private set; }
+        public ushort MaxX { get; private set; }
         
         public bool IsEmpty => _rectangles.Count == 0;
         private IReadOnlyList<PixelRect> _rectangles;
@@ -24,8 +24,18 @@ namespace Consolonia.Core.Infrastructure
             CalculateMinMax();
         }
 
+        private void InitializeMinMax()
+        {
+            MinY = ushort.MaxValue;
+            MaxY = ushort.MinValue;
+            MinX = ushort.MaxValue;
+            MaxX = ushort.MinValue;
+        }
+
         private void CalculateMinMax()
         {
+            InitializeMinMax();
+            
             for (int i = 0; i < _rectangles.Count; i++)
             {
                 PixelRect rect = _rectangles[i];

--- a/src/Consolonia.Core/Infrastructure/Regions.cs
+++ b/src/Consolonia.Core/Infrastructure/Regions.cs
@@ -9,12 +9,33 @@ namespace Consolonia.Core.Infrastructure
     /// </summary>
     internal class Snapshot
     {
-        private readonly IReadOnlyList<PixelRect> _rectangles;
+        public ushort MinY { get; private set; } = ushort.MaxValue;
+        public ushort MaxY { get; private set; } = ushort.MinValue;
+        public ushort MinX { get; private set; } = ushort.MaxValue;
+        public ushort MaxX { get; private set; } = ushort.MinValue;
+        
+        public bool IsEmpty => _rectangles.Count == 0;
+        private IReadOnlyList<PixelRect> _rectangles;
 
         private Snapshot(IReadOnlyList<PixelRect> rectangles)
         {
             _rectangles = rectangles;
+
+            CalculateMinMax();
         }
+
+        private void CalculateMinMax()
+        {
+            for (int i = 0; i < _rectangles.Count; i++)
+            {
+                PixelRect rect = _rectangles[i];
+                MinY = ushort.Min(MinY, (ushort)rect.Y);
+                MaxY = ushort.Max(MaxY, (ushort)rect.Bottom);
+                MinX = ushort.Min(MinX, (ushort)rect.X);
+                MaxX = ushort.Max(MaxX, (ushort)rect.Right);
+            }
+        }
+
 
         /// <summary>
         ///     Checks if a point is contained within any rectangle.
@@ -86,6 +107,20 @@ namespace Consolonia.Core.Infrastructure
                     return snapshot;
                 }
             }
+        }
+
+        public void Intersect(int x, int y, ushort width, ushort height)
+        {
+            var result = new List<PixelRect>();
+            foreach (PixelRect rectangle in _rectangles)
+            {
+                PixelRect intersected = rectangle.Intersect(new PixelRect(x, y, width, height));
+                if(!intersected.IsEmpty())
+                    result.Add(intersected);
+            } 
+            
+            _rectangles = result.AsReadOnly();
+            CalculateMinMax();
         }
     }
 }

--- a/src/Consolonia.NUnit/UnitTestConsole.cs
+++ b/src/Consolonia.NUnit/UnitTestConsole.cs
@@ -94,6 +94,10 @@ namespace Consolonia.NUnit
         {
         }
 
+        public void StartInputLoop()
+        {
+        }
+
         public void Dispose()
         {
             _lifetime = null;
@@ -167,10 +171,6 @@ namespace Consolonia.NUnit
         public void SetupLifetime(ConsoloniaLifetime lifetime)
         {
             _lifetime = lifetime;
-        }
-
-        public void StartInputLoop()
-        {
         }
 
 #pragma warning disable CS0067

--- a/src/Consolonia.NUnit/UnitTestConsole.cs
+++ b/src/Consolonia.NUnit/UnitTestConsole.cs
@@ -169,6 +169,9 @@ namespace Consolonia.NUnit
             _lifetime = lifetime;
         }
 
+        public void StartInputLoop()
+        {
+        }
 
 #pragma warning disable CS0067
         public event Action Resized;

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -171,6 +171,10 @@ namespace Consolonia.PlatformSupport
             PrepareConsole();
         }
 
+        // todo: synchronization mess has been introduced in this PR. we are fighting race between dispatcher and local locks.
+        // It's not clear for each object what is safe and what is not and safe for what exactly. Some operations are supposed to
+        // be executed only from Dispatcher thread, while others form random. Some of them having race between each other while others race itself
+        // only. Would be great if someone could bring an approach of synchornization which is simple to track and understand.
         [MethodImpl(MethodImplOptions.Synchronized)]
         public override void StartInputLoop()
         {

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -7,7 +7,9 @@
 //
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -133,6 +135,7 @@ namespace Consolonia.PlatformSupport
         private readonly FastBuffer<(int, int)> _inputBuffer;
         private readonly InputProcessor<(int, int)> _inputProcessor;
         private readonly ParametrizedLogger _verboseLogger = Log.CreateInputLogger(LogEventLevel.Verbose);
+        private readonly ParametrizedLogger _errorLogger = Log.CreateInputLogger(LogEventLevel.Error);
 
         private Curses.Window _cursesWindow;
         private int _eraseCharacter;
@@ -162,30 +165,31 @@ namespace Consolonia.PlatformSupport
         {
             _inputBuffer = new FastBuffer<(int, int)>(ReadInputFunction);
             _inputProcessor = new InputProcessor<(int, int)>(GetMatchers());
-
-            StartEventLoop();
-        }
-
-        private void StartEventLoop()
-        {
+            
             // ReSharper disable VirtualMemberCallInConstructor
             PrepareConsole();
+        }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public override void StartInputLoop()
+        {
+            StartEventLoop();
+        }
+        
+        private void StartEventLoop()
+        {
             Task _ = Task.Run(async () =>
             {
                 await Helper.WaitDispatcherInitialized();
-
+                
                 _inputBuffer.StartReading();
 
                 while (!Disposed)
                     try
                     {
                         (int, int)[] inputs = _inputBuffer.Dequeue();
-                        await DispatchInputAsync(() =>
-                        {
-                            _keyModifiers = new KeyModifiers();
-                            _inputProcessor.ProcessChunk(inputs);
-                        });
+                        _keyModifiers = new KeyModifiers();
+                        _inputProcessor.ProcessChunk(inputs);
                     }
                     catch (Exception exception)
                     {
@@ -197,6 +201,11 @@ namespace Consolonia.PlatformSupport
         }
 
         private readonly List<(int code, int wch)> _rowInputBuffer = new(1000); //todo: low magic number
+        
+        /// <summary>
+        /// We have to read mouse events immediately once we've got mouse codes. Because the mouse queue is of the opposite direction in ncurses
+        /// </summary>
+        private readonly ConcurrentQueue<Curses.MouseEvent> _mouseEvents = new();
 
         /// <summary>
         ///     https://github.com/gui-cs/Terminal.Gui/blob/v2_develop/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs#L790
@@ -218,11 +227,30 @@ namespace Consolonia.PlatformSupport
                 int code = Curses.get_wch(out int wch);
                 if (code != Curses.ERR)
                 {
-                    _rowInputBuffer.Add((code, wch));
+                    
+
+                    // Pair KEY_MOUSE with its event on THIS thread, immediately.
+                    if (code == Curses.KEY_CODE_YES && wch == Curses.KeyMouse)
+                    {
+                        if (Curses.getmouse(out Curses.MouseEvent ev) == 0)
+                        {
+                            _mouseEvents.Enqueue(ev);
+                            _rowInputBuffer.Add((code, wch));
+                        }
+                        else
+                        {
+                            /*coding agents assure this is valid if error returned here*/
+                            _errorLogger.Log2("Error getting mouse event");
+                        }
+                    }
+                    else
+                    {
+                        _rowInputBuffer.Add((code, wch));
+                    }
 
                     if (_rowInputBuffer.Count == 1)
                         Curses.timeout(SequenceCollectTimeout);
-
+                    
                     //check if was escape, wait for one more escape
                     if (code != Curses.KEY_CODE_YES && wch == 27)
                     {
@@ -253,6 +281,7 @@ namespace Consolonia.PlatformSupport
             return [.. _rowInputBuffer];
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public override void PrepareConsole()
         {
             _cursesWindow = Curses.initscr();
@@ -368,7 +397,7 @@ namespace Consolonia.PlatformSupport
                 Capabilities |= ConsoleCapabilities.SupportsMouseCursor;
         }
 
-
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public override void RestoreConsole()
         {
             base.RestoreConsole();
@@ -400,6 +429,7 @@ namespace Consolonia.PlatformSupport
             return Version.Parse(versionOnly) >= Version.Parse("6.4");
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public override void PauseIO(Task task)
         {
             base.PauseIO(task);
@@ -556,14 +586,15 @@ namespace Consolonia.PlatformSupport
                         CheckSize();
                         return;
                     case Curses.KeyMouse:
-                        if (Curses.getmouse(out Curses.MouseEvent ev) == 0)
+                        if (_mouseEvents.TryDequeue(out Curses.MouseEvent ev))
                         {
                             _verboseLogger.Log2(
                                 $"Mouse Event: {ev.ID} - {string.Join(" ", ev.ButtonState.GetFlags())}");
                             HandleMouseInput(ev);
+                            return;
                         }
 
-                        return;
+                        throw new ConsoloniaException("Mouse event was produced but queue was empty");
                 }
 
                 Key k = MapCursesKey(wch);

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -132,10 +132,11 @@ namespace Consolonia.PlatformSupport
                 (RawPointerEventType.Wheel, EventClass.Wheel)
             ]);
 
+        private readonly ParametrizedLogger _errorLogger = Log.CreateInputLogger(LogEventLevel.Error);
+
         private readonly FastBuffer<(int, int)> _inputBuffer;
         private readonly InputProcessor<(int, int)> _inputProcessor;
         private readonly ParametrizedLogger _verboseLogger = Log.CreateInputLogger(LogEventLevel.Verbose);
-        private readonly ParametrizedLogger _errorLogger = Log.CreateInputLogger(LogEventLevel.Error);
 
         private Curses.Window _cursesWindow;
         private int _eraseCharacter;
@@ -165,7 +166,7 @@ namespace Consolonia.PlatformSupport
         {
             _inputBuffer = new FastBuffer<(int, int)>(ReadInputFunction);
             _inputProcessor = new InputProcessor<(int, int)>(GetMatchers());
-            
+
             // ReSharper disable VirtualMemberCallInConstructor
             PrepareConsole();
         }
@@ -175,13 +176,13 @@ namespace Consolonia.PlatformSupport
         {
             StartEventLoop();
         }
-        
+
         private void StartEventLoop()
         {
             Task _ = Task.Run(async () =>
             {
                 await Helper.WaitDispatcherInitialized();
-                
+
                 _inputBuffer.StartReading();
 
                 while (!Disposed)
@@ -201,9 +202,10 @@ namespace Consolonia.PlatformSupport
         }
 
         private readonly List<(int code, int wch)> _rowInputBuffer = new(1000); //todo: low magic number
-        
+
         /// <summary>
-        /// We have to read mouse events immediately once we've got mouse codes. Because the mouse queue is of the opposite direction in ncurses
+        ///     We have to read mouse events immediately once we've got mouse codes. Because the mouse queue is of the opposite
+        ///     direction in ncurses
         /// </summary>
         private readonly ConcurrentQueue<Curses.MouseEvent> _mouseEvents = new();
 
@@ -227,8 +229,6 @@ namespace Consolonia.PlatformSupport
                 int code = Curses.get_wch(out int wch);
                 if (code != Curses.ERR)
                 {
-                    
-
                     // Pair KEY_MOUSE with its event on THIS thread, immediately.
                     if (code == Curses.KEY_CODE_YES && wch == Curses.KeyMouse)
                     {
@@ -250,7 +250,7 @@ namespace Consolonia.PlatformSupport
 
                     if (_rowInputBuffer.Count == 1)
                         Curses.timeout(SequenceCollectTimeout);
-                    
+
                     //check if was escape, wait for one more escape
                     if (code != Curses.KEY_CODE_YES && wch == 27)
                     {
@@ -583,10 +583,7 @@ namespace Consolonia.PlatformSupport
                 switch (wch)
                 {
                     case Curses.KeyResize:
-                        _ = DispatchInputAsync(() =>
-                        {
-                            CheckSize();
-                        });
+                        _ = DispatchInputAsync(() => { CheckSize(); });
                         return;
                     case Curses.KeyMouse:
                         if (_mouseEvents.TryDequeue(out Curses.MouseEvent ev))

--- a/src/Consolonia.PlatformSupport/CursesConsole.cs
+++ b/src/Consolonia.PlatformSupport/CursesConsole.cs
@@ -583,7 +583,10 @@ namespace Consolonia.PlatformSupport
                 switch (wch)
                 {
                     case Curses.KeyResize:
-                        CheckSize();
+                        _ = DispatchInputAsync(() =>
+                        {
+                            CheckSize();
+                        });
                         return;
                     case Curses.KeyMouse:
                         if (_mouseEvents.TryDequeue(out Curses.MouseEvent ev))

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -119,7 +119,7 @@ namespace Consolonia.PlatformSupport
         {
             StartEventLoop();
         }
-        
+
         private void StartEventLoop()
         {
             Task.Run(async () =>

--- a/src/Consolonia.PlatformSupport/Win32Console.cs
+++ b/src/Consolonia.PlatformSupport/Win32Console.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
@@ -88,10 +89,9 @@ namespace Consolonia.PlatformSupport
                             ConsoleCapabilities.SupportsAltSolo;
             if (GetConsoleWindow() != IntPtr.Zero)
                 Capabilities |= ConsoleCapabilities.SupportsMouseCursor;
-
-            StartEventLoop();
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         public override void PauseIO(Task task)
         {
             base.PauseIO(task);
@@ -114,6 +114,12 @@ namespace Consolonia.PlatformSupport
             }
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public override void StartInputLoop()
+        {
+            StartEventLoop();
+        }
+        
         private void StartEventLoop()
         {
             Task.Run(async () =>


### PR DESCRIPTION
1) Rendering in Avalonia is a different thread from Dispatcher
2) Key/mouse input now can be raised on any thread now
3) Synchronization added for different parts to protect the buffer, cache, different fields and most important output buffer (the cause of the relevant bug ticket)